### PR TITLE
chore: record action items from code comments

### DIFF
--- a/docs/comment-action-plan.md
+++ b/docs/comment-action-plan.md
@@ -1,0 +1,18 @@
+# Comment-Derived Action Plan
+
+This plan tracks open follow-ups called out directly in code comments. Each item captures a logical, non-deprecated task that still needs implementation.
+
+## Quick Settings Tile Service
+- Implement haptic feedback in `provideHapticFeedback()` so tile interactions give tactile confirmation.
+- Add real status monitoring teardown inside `stopStatusMonitoring()` by keeping references to launched coroutines and cancelling them when the tile stops listening.
+- Replace the placeholder connection flow in `VoiceAssistantServiceConnection.connect()` with actual service binding and connection status propagation; update `isConnected` accordingly.
+
+## Voice Command Pipeline
+- Wire `VoiceCommandViewModel.initialize()` to collect and expose real-time results from `AudioProcessingService`, rather than leaving the collector unimplemented.
+- Persist command execution results in `WebSocketManager.handleCommandResult()` using the app’s storage/repository layer instead of only printing them.
+
+## Connection & Pairing Management
+- Implement repository-backed device cleanup in `ConnectionStatusViewModel.clearAllDevices()` (e.g., a `PairingRepository` method) so paired devices are removed from storage as well as UI state.
+
+## PC Discovery
+- Replace the heuristic string parsing in `PCDiscovery.parsePCInfo()` with proper JSON parsing of the API response and populate MAC addresses from ARP/NS lookups when available.


### PR DESCRIPTION
## Summary
- review inline comments to capture open implementation follow-ups
- document actionable, non-deprecated tasks in a single plan

## Testing
- not run (documentation-only change)

## Checklist
- [ ] builds
- [ ] tests
- [ ] docs updated
- [ ] breaking changes noted

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f9235e8d0832d9e77482684c7d68a)